### PR TITLE
Remove Confirm Password input in Sign Up form

### DIFF
--- a/src/_components/SignUpForm.tsx
+++ b/src/_components/SignUpForm.tsx
@@ -12,7 +12,6 @@ export default function SignUpForm() {
       <Input label='Name' name='name' />
       <Input label='Email address' name='email' />
       <Input label='Password' name='password' isPassword />
-      <Input label='Confirm Password' name='confirm-password' isPassword />
       <Button type='submit' className='mt-3'>
         Sign Up
       </Button>


### PR DESCRIPTION
## 📝 What’s changed
- Removed input Confirm Password from Sign Up form in /auth/signup/ routes

## 🎯 Why
- The form became more compact without redundant fields. It was not necessary to have a Confirm Password field as the Password Input has a 'Show password button'.